### PR TITLE
allow steps to be in any input kwarg, not just inputs

### DIFF
--- a/drain/util.py
+++ b/drain/util.py
@@ -299,6 +299,13 @@ def make_tuple(a):
     return (a,) if not type(a) in (list, tuple) else tuple(a)
 
 
+def get_collection_values(a):
+    if not hasattr(a, '__iter__'):
+        raise ValueError("Must pass iterable")
+
+    return a.values() if isinstance(a, dict) else a
+
+
 def dict_product(*d, **kwargs):
     """
     cartesian product of dict whose values are lists
@@ -518,12 +525,8 @@ def is_instance_collection(c, cls):
         # make sure it's iterable and not empty
         return False
 
-    if isinstance(c, dict):
-        # when c is a dict, we care about its values not its keys
-        c = c.values()
-
     cls = make_list(cls)
-    for i in c:
+    for i in get_collection_values(c):
         instance = False
         for cl in cls:
             if isinstance(i, cl):

--- a/tests/test_step.py
+++ b/tests/test_step.py
@@ -1,4 +1,5 @@
 from drain.step import *
+from drain import step
 import numpy as np
 import tempfile
 
@@ -133,3 +134,15 @@ def test_dump_hdf_dict():
 
     for k in r:
         assert r[k].equals(t.result[k])
+
+def test_expand_inputs():
+    s = Step(a=1, b={'c':Step(c=2)})
+    assert step._expand_inputs(s) == {s, Step(c=2)}
+
+def test_collect_kwargs():
+    s = Step(a=1, b={'c':Step(c=2)})
+    s.name = 'Step2'
+    assert step._collect_kwargs(s) == {
+            'Step2': {'a':1},
+            'Step': {'c':2}
+    }


### PR DESCRIPTION
This allows exploration to work with inputs in any kwarg, not just `inputs`. It just looks for any kwarg whose value is either a Step or a collection of Steps.